### PR TITLE
add stoat for java/gradle project

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,3 +20,7 @@ jobs:
       - name: Build Gradle Project
         run: |
           ./gradlew build --scan
+
+      - name: Run Stoat Action
+        uses: stoat-dev/stoat-action@v0
+        if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ gradle-app.setting
 .project
 # JDT-specific (Eclipse Java Development Tools)
 .classpath
+
+# ignore our generated file
+gradle-scan

--- a/.stoat/comment.hbs
+++ b/.stoat/comment.hbs
@@ -1,0 +1,11 @@
+| category | links |
+| :--- | :--- |
+| **test** | {{#if tasks.tests.static_hosting.link ~}}[ [results]({{ tasks.tests.static_hosting.link }}) ] {{/if ~}}
+{{#if tasks.jacoco.static_hosting.link ~}}[ [coverage]({{ tasks.jacoco.static_hosting.link }}) ] {{/if ~}} |
+| **check** | {{#if tasks.checkstyle.static_hosting.link ~}}[ [checkstyle]({{ tasks.checkstyle.static_hosting.link }}/main.html) ] {{/if ~}}
+{{#if tasks.spotbugs.static_hosting.link ~}}[ [spotbugs]({{ tasks.spotbugs.static_hosting.link }}) ] {{/if ~}}
+{{#if tasks.pmd.static_hosting.link ~}}[ [pmd]({{ tasks.pmd.static_hosting.link }}/main.html) ] {{/if ~}} |
+| **docs** | {{#if tasks.javadoc.static_hosting.link ~}}[ [javadoc]({{ tasks.javadoc.static_hosting.link }}) ] {{/if ~}}
+{{#if tasks.openapi.static_hosting.link ~}}[ [openapi]({{ tasks.openapi.static_hosting.link }}) ] {{/if ~}} |
+| **build** | {{#if tasks.dependencies.static_hosting.link ~}}[ [dependencies]({{ tasks.dependencies.static_hosting.link }})] {{/if ~}}
+{{#if tasks.scan.static_hosting.link ~}}[ [scan]({{ tasks.scan.static_hosting.link }}) ] {{/if ~}} |

--- a/.stoat/comment.hbs
+++ b/.stoat/comment.hbs
@@ -2,9 +2,9 @@
 | :--- | :--- |
 | **test** | {{#if tasks.tests.static_hosting.link ~}}[ [results]({{ tasks.tests.static_hosting.link }}) ] {{/if ~}}
 {{#if tasks.jacoco.static_hosting.link ~}}[ [coverage]({{ tasks.jacoco.static_hosting.link }}) ] {{/if ~}} |
-| **check** | {{#if tasks.checkstyle.static_hosting.link ~}}[ [checkstyle]({{ tasks.checkstyle.static_hosting.link }}/main.html) ] {{/if ~}}
+| **check** | {{#if tasks.checkstyle.static_hosting.link ~}}[ [checkstyle]({{ tasks.checkstyle.static_hosting.link }}) ] {{/if ~}}
 {{#if tasks.spotbugs.static_hosting.link ~}}[ [spotbugs]({{ tasks.spotbugs.static_hosting.link }}) ] {{/if ~}}
-{{#if tasks.pmd.static_hosting.link ~}}[ [pmd]({{ tasks.pmd.static_hosting.link }}/main.html) ] {{/if ~}} |
+{{#if tasks.pmd.static_hosting.link ~}}[ [pmd]({{ tasks.pmd.static_hosting.link }}) ] {{/if ~}} |
 | **docs** | {{#if tasks.javadoc.static_hosting.link ~}}[ [javadoc]({{ tasks.javadoc.static_hosting.link }}) ] {{/if ~}}
 {{#if tasks.openapi.static_hosting.link ~}}[ [openapi]({{ tasks.openapi.static_hosting.link }}) ] {{/if ~}} |
 | **build** | {{#if tasks.dependencies.static_hosting.link ~}}[ [dependencies]({{ tasks.dependencies.static_hosting.link }})] {{/if ~}}

--- a/.stoat/comment.hbs
+++ b/.stoat/comment.hbs
@@ -1,13 +1,13 @@
 | category | links |
 | :--- | :--- |
-| **test** | {{#if tasks.tests.static_hosting.link ~}}[ [results]({{ tasks.tests.static_hosting.link }}) ] {{/if ~}}
-{{#if tasks.jacoco.static_hosting.link ~}}[ [coverage]({{ tasks.jacoco.static_hosting.link }}) ] {{/if ~}} |
-| **check** | {{#if tasks.checkstyle.static_hosting.link ~}}[ [checkstyle]({{ tasks.checkstyle.static_hosting.link }}) ] {{/if ~}}
-{{#if tasks.spotbugs.static_hosting.link ~}}[ [spotbugs]({{ tasks.spotbugs.static_hosting.link }}) ] {{/if ~}}
-{{#if tasks.pmd.static_hosting.link ~}}[ [pmd]({{ tasks.pmd.static_hosting.link }}) ] {{/if ~}} |
-| **docs** | {{#if tasks.javadoc.static_hosting.link ~}}[ [javadoc]({{ tasks.javadoc.static_hosting.link }}) ] {{/if ~}}
-{{#if tasks.openapi.static_hosting.link ~}}[ [openapi]({{ tasks.openapi.static_hosting.link }}) ] {{/if ~}} |
-| **build** | {{#if tasks.dependencies.static_hosting.link ~}}[ [dependencies]({{ tasks.dependencies.static_hosting.link }})] {{/if ~}}
-{{#if tasks.scan.static_hosting.link ~}}[ [scan]({{ tasks.scan.static_hosting.link }}) ] {{/if ~}} |
+| **test** | {{#if plugins.static_hosting.tests.link ~}}[ [results]({{ plugins.static_hosting.tests.link }}) ] {{/if ~}}
+{{#if plugins.static_hosting.jacoco.link ~}}[ [coverage]({{ plugins.static_hosting.jacoco.link }}) ] {{/if ~}} |
+| **check** | {{#if plugins.static_hosting.checkstyle.link ~}}[ [checkstyle]({{ plugins.static_hosting.checkstyle.link }}) ] {{/if ~}}
+{{#if plugins.static_hosting.spotbugs.link ~}}[ [spotbugs]({{ plugins.static_hosting.spotbugs.link }}) ] {{/if ~}}
+{{#if plugins.static_hosting.pmd.link ~}}[ [pmd]({{ plugins.static_hosting.pmd.link }}) ] {{/if ~}} |
+| **docs** | {{#if plugins.static_hosting.javadoc.link ~}}[ [javadoc]({{ plugins.static_hosting.javadoc.link }}) ] {{/if ~}}
+{{#if plugins.static_hosting.openapi.link ~}}[ [openapi]({{ plugins.static_hosting.openapi.link }}) ] {{/if ~}} |
+| **build** | {{#if plugins.static_hosting.dependencies.link ~}}[ [dependencies]({{ plugins.static_hosting.dependencies.link }})] {{/if ~}}
+{{#if plugins.static_hosting.scan.link ~}}[ [scan]({{ plugins.static_hosting.scan.link }}) ] {{/if ~}} |
 
 {{{ views.plugins.job_runtime.github.chart }}}

--- a/.stoat/comment.hbs
+++ b/.stoat/comment.hbs
@@ -9,3 +9,5 @@
 {{#if tasks.openapi.static_hosting.link ~}}[ [openapi]({{ tasks.openapi.static_hosting.link }}) ] {{/if ~}} |
 | **build** | {{#if tasks.dependencies.static_hosting.link ~}}[ [dependencies]({{ tasks.dependencies.static_hosting.link }})] {{/if ~}}
 {{#if tasks.scan.static_hosting.link ~}}[ [scan]({{ tasks.scan.static_hosting.link }}) ] {{/if ~}} |
+
+{{ views.plugins.job_runtime.github.chart }}

--- a/.stoat/comment.hbs
+++ b/.stoat/comment.hbs
@@ -10,4 +10,4 @@
 | **build** | {{#if tasks.dependencies.static_hosting.link ~}}[ [dependencies]({{ tasks.dependencies.static_hosting.link }})] {{/if ~}}
 {{#if tasks.scan.static_hosting.link ~}}[ [scan]({{ tasks.scan.static_hosting.link }}) ] {{/if ~}} |
 
-{{ views.plugins.job_runtime.github.chart }}
+{{{ views.plugins.job_runtime.github.chart }}}

--- a/.stoat/config.yaml
+++ b/.stoat/config.yaml
@@ -2,33 +2,25 @@
 version: 1
 enabled: true
 comment_template_file: ".stoat/comment.hbs"
-tasks:
-  tests:
-    static_hosting:
+plugins:
+  job_runtime:
+    enabled: true
+  static_hosting:
+    tests:
       path: build/reports/tests/test
-  jacoco:
-    static_hosting:
+    jacoco:
       path: build/jacocoHtml
-  checkstyle:
-    static_hosting:
+    checkstyle:
       path: build/reports/checkstyle/main.html
-  spotbugs:
-    static_hosting:
+    spotbugs:
       path: build/reports/spotbugs/main
-  pmd:
-    static_hosting:
+    pmd:
       path: build/reports/pmd/main.html
-  javadoc:
-    static_hosting:
+    javadoc:
       path: build/docs/javadoc
-  openapi:
-    static_hosting:
+    openapi:
       path: build/swagger-code-petstore
-  dependencies:
-    static_hosting:
+    dependencies:
       path: build/reports/project/dependencies
-  scan:
-    static_hosting:
+    scan:
       path: gradle-scan
-  build-time-history:
-    job_runtime: {}

--- a/.stoat/config.yaml
+++ b/.stoat/config.yaml
@@ -1,0 +1,32 @@
+---
+version: 1
+enabled: true
+comment_template_file: ".stoat/comment.hbs"
+tasks:
+  tests:
+    static_hosting:
+      path: build/reports/tests/test
+  jacoco:
+    static_hosting:
+      path: build/jacocoHtml
+  checkstyle:
+    static_hosting:
+      path: build/reports/checkstyle/main.html
+  spotbugs:
+    static_hosting:
+      path: build/reports/spotbugs/main
+  pmd:
+    static_hosting:
+      path: build/reports/pmd/main.html
+  javadoc:
+    static_hosting:
+      path: build/docs/javadoc
+  openapi:
+    static_hosting:
+      path: build/swagger-code-petstore
+  dependencies:
+    static_hosting:
+      path: build/reports/project/dependencies
+  scan:
+    static_hosting:
+      path: gradle-scan

--- a/.stoat/config.yaml
+++ b/.stoat/config.yaml
@@ -31,4 +31,4 @@ tasks:
     static_hosting:
       path: gradle-scan
   build-time-history:
-    job_runtime:
+    job_runtime: {}

--- a/.stoat/config.yaml
+++ b/.stoat/config.yaml
@@ -30,3 +30,5 @@ tasks:
   scan:
     static_hosting:
       path: gradle-scan
+  build-time-history:
+    job_runtime:

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id "com.gradle.enterprise"  version "3.9"
+}
+
 rootProject.name = 'example-java'
 
 gradleEnterprise {
@@ -13,14 +17,13 @@ gradle.addBuildListener(new BuildAdapter(){
     void settingsEvaluated(Settings settings) {
         super.settingsEvaluated(settings)
 
-        File file = new File("build/gradle-scan/index.html")
-
-        new File(file.getParent()).mkdirs()
+        File file = new File("gradle-scan/index.html")
+        file.getParentFile().mkdirs()
 
         if (settings.pluginManager.hasPlugin("com.gradle.enterprise")) {
             settings.extensions["gradleEnterprise"].buildScan.with {
                 buildScanPublished { buildScan ->
-                    file.write """
+                    file.text = """
                             <!DOCTYPE html>
                             <html>
                               <head>

--- a/src/test/java/org/openapitools/OpenApiGeneratorApplicationTests.java
+++ b/src/test/java/org/openapitools/OpenApiGeneratorApplicationTests.java
@@ -3,6 +3,7 @@ package org.openapitools;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
@@ -16,8 +17,8 @@ class OpenApiGeneratorApplicationTests {
     @Test
     void compareLists() {
         String[] expected = new String[]{"a", "b", "c"};
-        String[] actual = new String[]{"A", "b", "c"};
-        assertEquals(expected, actual);
+        String[] actual = new String[]{"a", "b", "c"};
+        assertArrayEquals(expected, actual);
     }
 
 }


### PR DESCRIPTION
Video describing explaining this PR: https://youtu.be/CXnFvUBcCbc

This PR contains an example of information that you can scrape and use for Stoat's static hosting plugin.

Here we collect the following resources for each build:
- test results
- test coverage reports
- checkstyle reports
- spotbugs reports
- pmd violation reports
- javadocs
- swagger/openapi docs
- build dependencies
- a link to the Gradle build scan

All of these items are updated in a single static comment on each PR, with links to each of those resources. Additionally, if you want to be able to view these locally as you develop on Mac/Linux, you can by installing Node/NPM and then running the following commands in the project:
```
npm i -g stoat
stoat local
```

Running `stoat local` will open a browser window with links to local versions of your files.